### PR TITLE
Add ec2:CreateTags as an edge case

### DIFF
--- a/aws_iam_role.website-pod-tester.tf
+++ b/aws_iam_role.website-pod-tester.tf
@@ -52,6 +52,7 @@ data "aws_iam_policy_document" "website-pod-tester-permissions" {
       "autoscaling:DescribeAutoScalingGroups",
       "autoscaling:DescribeScalingActivities",
       "ec2:CreateLaunchTemplate",
+      "ec2:CreateTags",
       "ec2:DescribeImages",
       "ec2:DescribeInstanceAttribute",
       "ec2:DescribeInstanceCreditSpecifications",


### PR DESCRIPTION
`ec2:CreateTags` is a dependency for a new permission. But
`ec2:CreateTags` was already in the exiting permissions so it didn't
make it to the list of new permissions. We still want it in the new
permissions to make the new policy valid.
