### PR TITLE
Remove itself as allowed role to assume

### DIFF
--- a/aws_iam_role.website-pod-tester.tf
+++ b/aws_iam_role.website-pod-tester.tf
@@ -12,7 +12,6 @@ data "aws_iam_policy_document" "website-pod-tester-assume" {
       type = "AWS"
       identifiers = [
         "arn:aws:iam::990466748045:user/aleks",
-        "arn:aws:iam::303467602807:role/${local.website_pod_tester_role_name}"
       ]
     }
   }


### PR DESCRIPTION
I wish AWS told what exactly was wrong in `MalformedPolicyDocument` so
have to guess.

My theory is the the role `website-pod-tester` doesn't like to have itself as a principal.
At the momenet of creation the role doesn't exist, obviously.

The `website-pod-tester` configuration was copy&pasted from the
`service-network-tester` where it was added as a principal later. The
role service-network-tester is used by a GHA worker as well as pytest.

Definitely, the roles should be less convoluted.
