### PR TITLE
Separate pytest required permissions into a policy

### DIFF
--- a/aws_iam_policy.pytest-permissions.tf
+++ b/aws_iam_policy.pytest-permissions.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_policy" "pytest-permissions" {
-  provider = aws.aws-303467602807-uw1
-  name     = "pytest-permissions"
-  policy   = data.aws_iam_policy_document.pytest-permissions.json
+  provider    = aws.aws-303467602807-uw1
+  name_prefix = "pytest-permissions"
+  policy      = data.aws_iam_policy_document.pytest-permissions.json
 }

--- a/aws_iam_policy.pytest-permissions.tf
+++ b/aws_iam_policy.pytest-permissions.tf
@@ -1,0 +1,5 @@
+resource "aws_iam_policy" "pytest-permissions" {
+  provider = aws.aws-303467602807-uw1
+  name     = "pytest-permissions"
+  policy   = data.aws_iam_policy_document.pytest-permissions.json
+}

--- a/aws_iam_role.gha-admin-tester.tf
+++ b/aws_iam_role.gha-admin-tester.tf
@@ -90,3 +90,9 @@ resource "aws_iam_role_policy_attachment" "gha-admin-tester" {
   policy_arn = aws_iam_policy.gha-admin-tester-permissions.arn
   role       = aws_iam_role.gha-admin-tester.name
 }
+
+resource "aws_iam_role_policy_attachment" "gha-admin-tester-pytest-permissions" {
+  provider   = aws.aws-303467602807-uw1
+  policy_arn = aws_iam_policy.pytest-permissions.arn
+  role       = aws_iam_role.gha-admin-tester.name
+}

--- a/aws_iam_role.service-network-tester.tf
+++ b/aws_iam_role.service-network-tester.tf
@@ -68,7 +68,6 @@ data "aws_iam_policy_document" "service-network-tester-permissions" {
       "ec2:DescribeNatGateways",
       "ec2:DescribeNetworkAcls",
       "ec2:DescribeNetworkInterfaces",
-      "ec2:DescribeRegions",
       "ec2:DescribeRouteTables",
       "ec2:DescribeSecurityGroupRules",
       "ec2:DescribeSecurityGroups",
@@ -113,5 +112,11 @@ resource "aws_iam_role" "service-network-tester" {
 resource "aws_iam_role_policy_attachment" "service-network-tester" {
   provider   = aws.aws-303467602807-uw1
   policy_arn = aws_iam_policy.service-network-tester-permissions.arn
+  role       = aws_iam_role.service-network-tester.name
+}
+
+resource "aws_iam_role_policy_attachment" "service-network-tester-pytest-permissions" {
+  provider   = aws.aws-303467602807-uw1
+  policy_arn = aws_iam_policy.pytest-permissions.arn
   role       = aws_iam_role.service-network-tester.name
 }

--- a/data_sources.tf
+++ b/data_sources.tf
@@ -7,3 +7,16 @@ data "aws_iam_policy" "read-only-access" {
   provider = aws.aws-303467602807-uw1
   name     = "ReadOnlyAccess"
 }
+
+
+# Common permissions for pytest fixtures
+# used ny terraform unit tests
+data "aws_iam_policy_document" "pytest-permissions" {
+  provider = aws.aws-303467602807-uw1
+  statement {
+    actions = [
+      "ec2:DescribeRegions",
+    ]
+    resources = ["*"]
+  }
+}


### PR DESCRIPTION
Some permissions are needed for all roles used for terraform unit tests.
Instead of specifying them individually for each role, separate them
into a dedicated IAM policy and attach the IAM policy to all roles that
need them.
