### PR TITLE
Add gha-admin-tester permissions

### DIFF
--- a/aws_iam_role.gha-admin-tester.tf
+++ b/aws_iam_role.gha-admin-tester.tf
@@ -63,6 +63,7 @@ data "aws_iam_policy_document" "gha-admin-tester-permissions" {
       "iam:TagRole",
       "s3:CreateBucket",
       "s3:DeleteBucket",
+      "s3:HeadBucket",
       "s3:PutBucketTagging",
       "dynamodb:CreateTable",
       "dynamodb:DeleteTable",


### PR DESCRIPTION
Allow "s3:HeadBucket". Discovered with

```
$ ih-plan min-permissions --existing-actions apply.json tf-apply-trace.txt
```
