### PR TITLE
Fix gha-admin-tester permissions

### DIFF
--- a/aws_iam_role.gha-admin-tester.tf
+++ b/aws_iam_role.gha-admin-tester.tf
@@ -63,7 +63,7 @@ data "aws_iam_policy_document" "gha-admin-tester-permissions" {
       "iam:TagRole",
       "s3:CreateBucket",
       "s3:DeleteBucket",
-      "s3:HeadBucket",
+      "s3:ListBucket",
       "s3:PutBucketTagging",
       "dynamodb:CreateTable",
       "dynamodb:DeleteTable",


### PR DESCRIPTION
There is no s3:HeadBucket permission. This operation requires
ListBucket. See
https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html
