### PR TITLE
Add remaining permissions to gha-admin-tester

### DIFF
--- a/aws_iam_role.gha-admin-tester.tf
+++ b/aws_iam_role.gha-admin-tester.tf
@@ -43,6 +43,13 @@ data "aws_iam_policy_document" "gha-admin-tester-assume" {
 data "aws_iam_policy_document" "gha-admin-tester-permissions" {
   statement {
     actions = [
+      "dynamodb:CreateTable",
+      "dynamodb:DeleteTable",
+      "dynamodb:DescribeContinuousBackups",
+      "dynamodb:DescribeTable",
+      "dynamodb:DescribeTimeToLive",
+      "dynamodb:ListTagsOfResource",
+      "dynamodb:TagResource",
       "iam:AttachRolePolicy",
       "iam:CreatePolicy",
       "iam:CreateRole",
@@ -63,15 +70,21 @@ data "aws_iam_policy_document" "gha-admin-tester-permissions" {
       "iam:TagRole",
       "s3:CreateBucket",
       "s3:DeleteBucket",
+      "s3:GetBucketAccelerateConfiguration",
       "s3:GetBucketAcl",
       "s3:GetBucketCors",
+      "s3:GetBucketEncryption",
+      "s3:GetBucketLifecycleConfiguration",
+      "s3:GetBucketLogging",
       "s3:GetBucketPolicy",
+      "s3:GetBucketReplication",
+      "s3:GetBucketRequestPayment",
+      "s3:GetBucketTagging",
+      "s3:GetBucketVersioning",
       "s3:GetBucketWebsite",
+      "s3:GetObjectLockConfiguration",
       "s3:ListBucket",
       "s3:PutBucketTagging",
-      "dynamodb:CreateTable",
-      "dynamodb:DeleteTable",
-      "dynamodb:TagResource",
       "sts:AssumeRole",
       "sts:GetCallerIdentity"
     ]


### PR DESCRIPTION
Adding permissions one by one is time consuming.
Instead, I manually attached `AdministratorAccess` policy to the
`gha-admin-tester` role and ran `make test` in
`infrahouse/terraform-aws-gha-admin` with `TRACE_TERRAFORM = True`.

All that made pytest collect necessary permissions in the trace files
`tf-apply-trace.txt` and `tf-destroy-trace.txt`.
To get the permissions I ran a command
```
ih-plan min-permissions tf-apply-trace.txt
```

Note:

> * `ih-plan min-permissions` work only with the AWS provider version 5.11. In further versions they broke something. I didn't look yet.
> * `s3:HeadBucket` operation corresponds to `s3:ListBucket` permission. `ih-plan min-permissions` should be smart to handle it, but it's not. yet.
