### PR TITLE
Add tagging permissions for pytest

### DIFF
--- a/data_sources.tf
+++ b/data_sources.tf
@@ -15,7 +15,13 @@ data "aws_iam_policy_document" "pytest-permissions" {
   provider = aws.aws-303467602807-uw1
   statement {
     actions = [
+      "dynamodb:ListTagsOfResource",
+      "dynamodb:TagResource",
       "ec2:DescribeRegions",
+      "iam:TagPolicy",
+      "iam:TagRole",
+      "s3:GetBucketTagging",
+      "s3:PutBucketTagging"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
pytest uses a provider that tags created resources. Grant some tagging
permissions so it can do it.
Unfortunately, these tagging operations do not get to a trace file so
they're invisible to the `ih-plan min-permissions` command.
