### PR TITLE
Grant a tester role at least one permission

### DIFF
--- a/modules/module-tester-role/data_sources.tf
+++ b/modules/module-tester-role/data_sources.tf
@@ -59,7 +59,7 @@ data "aws_iam_policy_document" "role-trust" {
 
 data "aws_iam_policy_document" "role-permissions" {
   statement {
-    actions   = var.role_permissions
+    actions   = length(var.role_permissions) > 0 ? var.role_permissions : ["sts:GetCallerIdentity"]
     resources = ["*"]
   }
 }


### PR DESCRIPTION
A permission policy statement must have at least one action. If the user
passed empty permissions list, give 'sts:GetCallerIdentity'.
