### PR TITLE
Add role ecs-tester

### DIFF
--- a/aws_iam_role.ecs-tester.tf
+++ b/aws_iam_role.ecs-tester.tf
@@ -9,7 +9,7 @@ module "ecs-tester" {
   trusted_iam_user_arn = {
     "me" : local.me_arn
   }
-  role_permissions = []
+  role_permissions        = []
   grant_admin_permissions = true
 }
 

--- a/aws_iam_role.ecs-tester.tf
+++ b/aws_iam_role.ecs-tester.tf
@@ -1,0 +1,26 @@
+module "ecs-tester" {
+  source = "./modules/module-tester-role"
+  providers = {
+    aws = aws.aws-303467602807-uw1
+  }
+  gh_org_name = "infrahouse"
+  repo_name   = "terraform-aws-ecs"
+  role_name   = "ecs-tester"
+  trusted_iam_user_arn = {
+    "me" : local.me_arn
+  }
+  role_permissions = []
+  grant_admin_permissions = true
+}
+
+resource "aws_iam_role_policy_attachment" "ecs-tester-service-network-permissions" {
+  provider   = aws.aws-303467602807-uw1
+  policy_arn = aws_iam_policy.service-network-tester-permissions.arn
+  role       = module.ecs-tester.role_name
+}
+
+resource "aws_iam_role_policy_attachment" "ecs-tester-website-pod-permissions" {
+  provider   = aws.aws-303467602807-uw1
+  policy_arn = aws_iam_policy.website-pod-tester-permissions.arn
+  role       = module.ecs-tester.role_name
+}


### PR DESCRIPTION
The role is to test [infrahouse/terraform-aws-ecs](https://github.com/infrahouse/terraform-aws-ecs)

It needs `aws_iam_policy.service-network-tester-permissions.arn` and `aws_iam_policy.website-pod-tester-permissions.arn` because respective modules are dependencies.
