### PR TITLE
Add role elasticsearch-tester

### DIFF
--- a/aws_iam_role.elasticsearch-tester.tf
+++ b/aws_iam_role.elasticsearch-tester.tf
@@ -1,0 +1,26 @@
+module "elasticsearch-tester" {
+  source = "./modules/module-tester-role"
+  providers = {
+    aws = aws.aws-303467602807-uw1
+  }
+  gh_org_name = "infrahouse"
+  repo_name   = "terraform-aws-elasticsearch"
+  role_name   = "elasticsearch-tester"
+  trusted_iam_user_arn = {
+    "me" : local.me_arn
+  }
+  role_permissions        = []
+  grant_admin_permissions = true
+}
+
+resource "aws_iam_role_policy_attachment" "elasticsearch-tester-service-network-permissions" {
+  provider   = aws.aws-303467602807-uw1
+  policy_arn = aws_iam_policy.service-network-tester-permissions.arn
+  role       = module.elasticsearch-tester.role_name
+}
+
+resource "aws_iam_role_policy_attachment" "elasticsearch-tester-website-pod-permissions" {
+  provider   = aws.aws-303467602807-uw1
+  policy_arn = module.website-pod-tester.permissions_policy_arn
+  role       = module.elasticsearch-tester.role_name
+}


### PR DESCRIPTION
The role is to run tests on the terraform-aws-elasticsearch repo.
