### PR TITLE
instance profile tester

### DIFF
--- a/aws_iam_role.instance-profile-tester.tf
+++ b/aws_iam_role.instance-profile-tester.tf
@@ -9,6 +9,8 @@ module "instance-profile-tester" {
   trusted_iam_user_arn = {
     "me" : local.me_arn
   }
-  role_permissions        = []
+  role_permissions = [
+    "sts:GetCallerIdentity"
+  ]
   grant_admin_permissions = true
 }

--- a/aws_iam_role.instance-profile-tester.tf
+++ b/aws_iam_role.instance-profile-tester.tf
@@ -9,8 +9,6 @@ module "instance-profile-tester" {
   trusted_iam_user_arn = {
     "me" : local.me_arn
   }
-  role_permissions = [
-    "sts:GetCallerIdentity"
-  ]
+  role_permissions        = []
   grant_admin_permissions = true
 }

--- a/modules/module-tester-role/data_sources.tf
+++ b/modules/module-tester-role/data_sources.tf
@@ -20,10 +20,16 @@ data "aws_iam_policy_document" "pytest-permissions" {
   }
 }
 
+data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy_document" "role-trust" {
   dynamic "statement" {
-    for_each = var.trusted_iam_user_arn
+    for_each = merge(
+      var.trusted_iam_user_arn,
+      {
+        self : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.role_name}"
+      }
+    )
     content {
       actions = ["sts:AssumeRole"]
       principals {


### PR DESCRIPTION
- grant sts:GetCallerIdentity to instance-profile-tester
- a tester role should trust itself
