### PR TITLE
Setup trust statemet for self role

### DIFF
--- a/modules/module-tester-role/data_sources.tf
+++ b/modules/module-tester-role/data_sources.tf
@@ -26,9 +26,6 @@ data "aws_iam_policy_document" "role-trust" {
   dynamic "statement" {
     for_each = merge(
       var.trusted_iam_user_arn,
-      {
-        self : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.role_name}"
-      }
     )
     content {
       actions = ["sts:AssumeRole"]
@@ -36,6 +33,22 @@ data "aws_iam_policy_document" "role-trust" {
         type        = "AWS"
         identifiers = [statement.value]
       }
+    }
+  }
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.role_name}"
+      ]
+      type = "AWS"
+    }
+    condition {
+      test = "ArnEquals"
+      values = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.role_name}"
+      ]
+      variable = "aws:PrincipalArn"
     }
   }
   statement {


### PR DESCRIPTION
Sometimes ARN in a trusted roles fails if the role doesn't exist yet
See
https://github.com/hashicorp/terraform-provider-aws/issues/27034

Workaround from there, too.
