### PR TITLE
Install debhelper

### DIFF
--- a/gha_runner.tf
+++ b/gha_runner.tf
@@ -25,7 +25,7 @@ module "actions-runner" {
   extra_labels               = ["oracular", "hugo"]
   puppet_hiera_config_path   = "/opt/infrahouse-puppet-data/environments/${local.environment}/hiera.yaml"
   packages = [
-    "debhelper-compat",
+    "debhelper",
     "devscripts",
     "infrahouse-puppet-data",
     "golang",


### PR DESCRIPTION
Otherwise, there is an error:
```
2024-12-22 06:57:00,741 - apt.py[DEBUG]: The following packages were not found by APT so APT will not attempt to install them: ['debhelper-compat']
```
