### PR TITLE
Bump website-pod-tester lifetime to 12 hours

### DIFF
--- a/aws_iam_role.website-pod-tester.tf
+++ b/aws_iam_role.website-pod-tester.tf
@@ -90,6 +90,7 @@ module "website-pod-tester" {
     "route53:ListTagsForResource",
   ]
   grant_admin_permissions = true
+  max_session_duration    = 12 * 3600
 }
 
 resource "aws_iam_role_policy_attachment" "website-pod-tester-sernive-network-permissions" {


### PR DESCRIPTION
the tests run over one hour now