### PR TITLE
Use spot instances for oracular

### DIFF
--- a/gha_runner.tf
+++ b/gha_runner.tf
@@ -15,6 +15,7 @@ module "actions-runner" {
   instance_type              = "t3a.small"
   root_volume_size           = 64
   max_instance_lifetime_days = 5
+  on_demand_base_capacity    = 0
   asg_min_size               = 1
   asg_max_size               = 1
   ubuntu_codename            = "oracular"


### PR DESCRIPTION
We never need more than one oracular instance - it builds the website
only.
So, disable the warm pool and use the spot instances instead.
