### PR TITLE
Grant ec2:DescribeRegions to role ih-tf-infrahouse-ubuntu-pro-github

### DIFF
--- a/infrahouse-ubuntu-pro-ami.tf
+++ b/infrahouse-ubuntu-pro-ami.tf
@@ -11,6 +11,7 @@ data "aws_iam_policy_document" "infrahouse-ubuntu-pro-permissions" {
   statement {
     effect = "Allow"
     actions = [
+      "ec2:DescribeRegions",
       "sts:GetCallerIdentity",
     ]
     resources = ["*"]


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI


### What change is being made?

Grant the `ec2:DescribeRegions` permission to the role `ih-tf-infrahouse-ubuntu-pro-github` by updating the IAM policy document.

### Why are these changes being made?

This change allows the role to query available AWS regions, which is necessary for dynamic infrastructure organization and automation that depends on region-specific configurations or resources. It enhances the role's capabilities by providing more comprehensive regional insights without compromising security, as the permissions are read-only.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->