### PR TITLE
Use the latest 2.17.0 version of infrahouse/actions-runner/aws

### DIFF
--- a/gha_runner.tf
+++ b/gha_runner.tf
@@ -34,7 +34,7 @@ module "actions-runner" {
 
 module "actions-runner-noble" {
   source  = "registry.infrahouse.com/infrahouse/actions-runner/aws"
-  version = "2.15.1"
+  version = "2.17.0"
 
   environment                = local.environment
   github_org_name            = "infrahouse"


### PR DESCRIPTION
2.17.0 is required with InfraHouse AMI because it uses correct cloud-init module
