### PR TITLE
Upgrade actions-runner module to 3.4.2

### DIFF
--- a/gha_runner.tf
+++ b/gha_runner.tf
@@ -4,7 +4,7 @@ data "aws_secretsmanager_secret" "github-terraform-app-key" {
 
 module "actions-runner-noble" {
   source  = "registry.infrahouse.com/infrahouse/actions-runner/aws"
-  version = "3.4.1"
+  version = "3.4.2"
 
   environment                = local.environment
   github_org_name            = "infrahouse"


### PR DESCRIPTION
## Summary
- Bumps `infrahouse/actions-runner/aws` module from 3.4.1 to 3.4.2
- Patch release that bumps `infrahouse-core` to ~= 1.0 to reduce Lambda memory pressure
- No input/variable changes

## Test plan
- [ ] CI lint and `terraform plan` succeed
- [ ] Plan shows only Lambda code/package changes (no infrastructure surprises)

🤖 Generated with [Claude Code](https://claude.com/claude-code)