### PR TITLE
Upgrade actions-runner module to 3.4.3

### DIFF
--- a/gha_runner.tf
+++ b/gha_runner.tf
@@ -4,7 +4,7 @@ data "aws_secretsmanager_secret" "github-terraform-app-key" {
 
 module "actions-runner-noble" {
   source  = "registry.infrahouse.com/infrahouse/actions-runner/aws"
-  version = "3.4.2"
+  version = "3.4.3"
 
   environment                = local.environment
   github_org_name            = "infrahouse"


### PR DESCRIPTION
## Summary
- Bumps `infrahouse/actions-runner/aws` module from 3.4.2 to 3.4.3
- Patch release that raises Lambda memory to 512 MB and hoists boto3 clients to module scope (performance/reliability fix)
- No input/variable changes

## Test plan
- [ ] CI lint and `terraform plan` succeed
- [ ] Plan shows only Lambda memory + code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)