### PR TITLE
feat: enable Inspector2 EC2 scanning in us-west-2 and us-east-1

### DIFF
--- a/inspector.tf
+++ b/inspector.tf
@@ -1,0 +1,20 @@
+# Amazon Inspector EC2 scanning.
+#
+# Required for the terraform-aws-instance-profile CIS e2e test: Inspector CIS
+# benchmark scans ride on the EC2 scanning resource type, and the test account
+# must have it activated for scan configurations to run.
+# https://github.com/infrahouse/terraform-aws-instance-profile/issues/33
+#
+# Cost: EC2 scanning is billed prorated per running instance
+# (~$1.26/instance-month); CI instances are transient, so the idle cost is
+# zero. CIS assessments are $0.03 per instance per scan.
+resource "aws_inspector2_enabler" "this" {
+  for_each = toset([
+    "us-west-2",
+    "us-east-1",
+  ])
+
+  region         = each.value
+  account_ids    = [data.aws_caller_identity.current.account_id]
+  resource_types = ["EC2"]
+}


### PR DESCRIPTION
## What

Enables Amazon Inspector2 EC2 scanning in the test account for `us-west-2` and `us-east-1`, via `aws_inspector2_enabler` with `for_each` over the regions (provider 6.x per-resource `region`).

## Why

Prerequisite for the CIS e2e test in infrahouse/terraform-aws-instance-profile#33: Inspector CIS benchmark scans ride on the EC2 scanning resource type, and scan configurations can't run in an account where it's disabled (current status: fully DISABLED).

The `instance-profile-tester` role needs no changes — tester roles carry `grant_admin_permissions = true` (AdministratorAccess), which covers instance lifecycle and `inspector2` scan-configuration management.

## Cost

- EC2 scanning: ~$1.26/instance-month, prorated per running instance — CI instances are transient, so idle cost is zero. Note: every CI instance in the account gets vulnerability-scanned while it lives (~$0.002/instance-hour).
- CIS assessments: $0.03 per instance per scan (~one scan per e2e test run).
- Inspector findings for transient CI instances will start appearing; nothing in this account aggregates them today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)